### PR TITLE
Adding workflow dispatch trigger to debug workflow

### DIFF
--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -5,6 +5,8 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  # to debug workflow
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
Workflow dispatch only works on workflows that have run at least once on that branch-- this PR should trigger the workflow.